### PR TITLE
test/member-auth-test

### DIFF
--- a/src/main/java/com/auction/bid/BidApplication.java
+++ b/src/main/java/com/auction/bid/BidApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class BidApplication {
 

--- a/src/main/java/com/auction/bid/domain/member/Address.java
+++ b/src/main/java/com/auction/bid/domain/member/Address.java
@@ -2,11 +2,12 @@ package com.auction.bid.domain.member;
 
 import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.NotEmpty;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 @Getter
 public class Address {
 

--- a/src/main/java/com/auction/bid/domain/member/dto/EmailDto.java
+++ b/src/main/java/com/auction/bid/domain/member/dto/EmailDto.java
@@ -2,9 +2,12 @@ package com.auction.bid.domain.member.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class EmailDto {
 
     @Email(message = "유효한 이메일을 입력하세요.")

--- a/src/main/java/com/auction/bid/domain/member/dto/SignUpDto.java
+++ b/src/main/java/com/auction/bid/domain/member/dto/SignUpDto.java
@@ -19,25 +19,25 @@ public class SignUpDto {
     @AllArgsConstructor
     public static class Request{
 
-        @NotEmpty
+        @NotEmpty(message = "아이디를 입력해주세요.")
         private String loginId;
 
-        @NotEmpty
+        @NotEmpty(message = "비밀번호를 입력해주세요.")
         private String password;
 
-        @NotEmpty
+        @NotEmpty(message = "이메일을 입력해주세요.")
         private String email;
 
-        @NotEmpty
+        @NotEmpty(message = "닉네임을 입력해주세요.")
         private String nickname;
 
-        @NotEmpty
+        @NotEmpty(message = "이름을 입력해주세요.")
         private String name;
 
-        @NotEmpty
+        @NotEmpty(message = "휴대폰 번호를 입력해주세요.")
         private String phoneNumber;
 
-        @NotNull
+        @NotNull(message = "must not be null")
         private Boolean emailVerified;
 
         @Valid
@@ -64,6 +64,8 @@ public class SignUpDto {
     }
 
     @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @Getter
     public static class Response {
         private Long id;

--- a/src/main/java/com/auction/bid/domain/member/dto/TokenVerificationDto.java
+++ b/src/main/java/com/auction/bid/domain/member/dto/TokenVerificationDto.java
@@ -3,9 +3,12 @@ package com.auction.bid.domain.member.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class TokenVerificationDto {
 
     @Email(message = "유효한 이메일을 입력하세요.")

--- a/src/main/java/com/auction/bid/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/auction/bid/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.auction.bid.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/auction/bid/global/config/SecurityConfig.java
+++ b/src/main/java/com/auction/bid/global/config/SecurityConfig.java
@@ -1,12 +1,11 @@
-package com.auction.bid.global.security.config;
+package com.auction.bid.global.config;
 
-import com.auction.bid.global.security.ConstSecurity;
+import com.auction.bid.global.oauth2.CustomAuthenticationFailureHandler;
+import com.auction.bid.global.oauth2.CustomAuthenticationSuccessHandler;
 import com.auction.bid.global.security.RefreshTokenRepository;
 import com.auction.bid.global.security.jwt.JWTFilter;
 import com.auction.bid.global.security.jwt.JWTUtil;
 import com.auction.bid.global.security.jwt.LoginFilter;
-import com.auction.bid.global.security.oauth2.CustomAuthenticationFailureHandler;
-import com.auction.bid.global.security.oauth2.CustomAuthenticationSuccessHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/auction/bid/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/auction/bid/global/exception/GlobalExceptionHandler.java
@@ -5,9 +5,13 @@ import com.auction.bid.global.exception.exceptions.MailException;
 import com.auction.bid.global.exception.exceptions.MemberException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -28,8 +32,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    public ResponseEntity<List<String>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        List<String> errors = ex.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage) // 각 오류의 기본 메시지를 가져옵니다.
+                .toList();
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/main/java/com/auction/bid/global/oauth2/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/auction/bid/global/oauth2/CustomAuthenticationFailureHandler.java
@@ -1,4 +1,4 @@
-package com.auction.bid.global.security.oauth2;
+package com.auction.bid.global.oauth2;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/auction/bid/global/oauth2/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/auction/bid/global/oauth2/CustomAuthenticationSuccessHandler.java
@@ -1,4 +1,4 @@
-package com.auction.bid.global.security.oauth2;
+package com.auction.bid.global.oauth2;
 
 import com.auction.bid.domain.member.Member;
 import com.auction.bid.domain.member.MemberRepository;
@@ -8,10 +8,10 @@ import com.auction.bid.global.security.ConstSecurity;
 import com.auction.bid.global.security.RefreshToken;
 import com.auction.bid.global.security.RefreshTokenRepository;
 import com.auction.bid.global.security.jwt.JWTUtil;
-import com.auction.bid.global.security.oauth2.userinfo.GoogleUserInfo;
-import com.auction.bid.global.security.oauth2.userinfo.KakaoUserInfo;
-import com.auction.bid.global.security.oauth2.userinfo.NaverUserInfo;
-import com.auction.bid.global.security.oauth2.userinfo.OAuth2UserInfo;
+import com.auction.bid.global.oauth2.userinfo.GoogleUserInfo;
+import com.auction.bid.global.oauth2.userinfo.KakaoUserInfo;
+import com.auction.bid.global.oauth2.userinfo.NaverUserInfo;
+import com.auction.bid.global.oauth2.userinfo.OAuth2UserInfo;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/auction/bid/global/oauth2/userinfo/GoogleUserInfo.java
+++ b/src/main/java/com/auction/bid/global/oauth2/userinfo/GoogleUserInfo.java
@@ -1,7 +1,5 @@
-package com.auction.bid.global.security.oauth2.userinfo;
+package com.auction.bid.global.oauth2.userinfo;
 
-import com.auction.bid.global.security.oauth2.userinfo.OAuth2UserInfo;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Map;

--- a/src/main/java/com/auction/bid/global/oauth2/userinfo/KakaoUserInfo.java
+++ b/src/main/java/com/auction/bid/global/oauth2/userinfo/KakaoUserInfo.java
@@ -1,6 +1,5 @@
-package com.auction.bid.global.security.oauth2.userinfo;
+package com.auction.bid.global.oauth2.userinfo;
 
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Map;

--- a/src/main/java/com/auction/bid/global/oauth2/userinfo/NaverUserInfo.java
+++ b/src/main/java/com/auction/bid/global/oauth2/userinfo/NaverUserInfo.java
@@ -1,4 +1,4 @@
-package com.auction.bid.global.security.oauth2.userinfo;
+package com.auction.bid.global.oauth2.userinfo;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/auction/bid/global/oauth2/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/com/auction/bid/global/oauth2/userinfo/OAuth2UserInfo.java
@@ -1,4 +1,4 @@
-package com.auction.bid.global.security.oauth2.userinfo;
+package com.auction.bid.global.oauth2.userinfo;
 
 public interface OAuth2UserInfo {
     String getProviderId();

--- a/src/test/java/com/auction/bid/domain/member/MemberControllerIntegrTest.java
+++ b/src/test/java/com/auction/bid/domain/member/MemberControllerIntegrTest.java
@@ -1,0 +1,130 @@
+package com.auction.bid.domain.member;
+
+import com.auction.bid.domain.member.dto.EmailDto;
+import com.auction.bid.domain.member.dto.SignUpDto;
+import com.auction.bid.global.security.ConstSecurity;
+import com.auction.bid.global.security.jwt.JWTUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+class MemberControllerIntegrTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JWTUtil jwtUtil;
+
+    SignUpDto.Request signUpReq;
+    SignUpDto.Response signUpRes;
+
+    @BeforeEach()
+    private void setUp() {
+        signUpReq = SignUpDto.Request.builder()
+                .loginId("testLoginId")
+                .password("1234567890")
+                .email("test@naver.com")
+                .nickname("testNickname")
+                .name("testName")
+                .phoneNumber("010-1234-5678")
+                .emailVerified(true)
+                .address(
+                        Address.builder()
+                                .city("seoul")
+                                .street("saemalo")
+                                .zipcode("548")
+                                .build())
+                .build();
+
+        signUpRes = SignUpDto.Response.builder()
+                .id(1L)
+                .loginId("resLoginId")
+                .name("resName")
+                .nickname("resNickName")
+                .build();
+
+    }
+
+    @Test
+    void member_signup_success() throws Exception {
+        postPerform("/auth/signup", signUpReq)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.nickname").value("testNickname"))
+                .andExpect(jsonPath("$.loginId").value("testLoginId"))
+                .andExpect(jsonPath("$.name").value("testName"));
+    }
+
+    @Test
+    @DisplayName("이메일 보내기 성공")
+    void server_send_email_success() throws Exception {
+        EmailDto emailDto = EmailDto.builder()
+                .email("kongminoo@naver.com")
+                .build();
+
+        postPerform("/auth/send-email", emailDto)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value("kongminoo@naver.com"));
+    }
+
+    @Test
+    @DisplayName("ROLE 멤버 로그아웃 성공")
+    void only_role_member_logged_out() throws Exception {
+        UUID uuid = UUID.randomUUID();
+        String accessToken = jwtUtil.generateAccessToken(
+                uuid,
+                ConstSecurity.ROLE_MEMBER,
+                5000L
+        );
+
+        mockMvc.perform(post("/api/member/auth/logout")
+                        .header(ConstSecurity.AUTHORIZATION, ConstSecurity.BEARER + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value(uuid.toString()));
+    }
+
+    @Test
+    @DisplayName("ROLE 어드민 로그아웃 실패")
+    void admin_role_denied() throws Exception {
+        UUID uuid = UUID.randomUUID();
+        String accessToken = jwtUtil.generateAccessToken(
+                uuid,
+                ConstSecurity.ROLE_ADMIN,
+                5000L
+        );
+
+        mockMvc.perform(post("/api/member/auth/logout")
+                        .header(ConstSecurity.AUTHORIZATION, ConstSecurity.BEARER + accessToken))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    private ResultActions postPerform(String uri, Object requestDto) throws Exception {
+        return mockMvc.perform(post("/api/member" + uri)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andDo(print());
+    }
+
+}

--- a/src/test/java/com/auction/bid/domain/member/MemberControllerUnitTest.java
+++ b/src/test/java/com/auction/bid/domain/member/MemberControllerUnitTest.java
@@ -1,0 +1,169 @@
+package com.auction.bid.domain.member;
+
+import com.auction.bid.domain.member.dto.EmailDto;
+import com.auction.bid.domain.member.dto.SignUpDto;
+import com.auction.bid.domain.member.dto.TokenVerificationDto;
+import com.auction.bid.global.security.ConstSecurity;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+class MemberControllerUnitTest {
+
+    @MockitoBean
+    private MemberService memberService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private SignUpDto.Request signUpReq;
+    private SignUpDto.Response signUpRes;
+
+    @BeforeEach()
+    private void setUp() {
+        signUpReq = SignUpDto.Request.builder()
+                .loginId("testLoginId")
+                .password("1234567890")
+                .email("test@naver.com")
+                .nickname("testNickname")
+                .name("testName")
+                .phoneNumber("010-1234-5678")
+                .emailVerified(true)
+                .address(
+                        Address.builder()
+                                .city("seoul")
+                                .street("saemalo")
+                                .zipcode("548")
+                                .build())
+                .build();
+
+        signUpRes = SignUpDto.Response.builder()
+                .id(1L)
+                .loginId("resLoginId")
+                .name("resName")
+                .nickname("resNickName")
+                .build();
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("회원가입 성공")
+    void signup_success() throws Exception {
+        when(memberService.signUp(any())).thenReturn(signUpRes);
+
+        postPerform("/auth/signup", signUpReq)
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.loginId").value("resLoginId"))
+                .andExpect(jsonPath("$.nickname").value("resNickName"));
+
+        verify(memberService, times(1)).signUp(any());
+    }
+
+    @Test
+    @DisplayName("Dto 누락했을 시 예외반환")
+    @WithMockUser
+    void emptyDto_throws_ex() throws Exception {
+        signUpReq = SignUpDto.Request.builder()
+                .address(
+                        Address.builder()
+                                .city("seoul")
+                                .street("saemalo")
+                                .zipcode("548")
+                                .build())
+                .build();
+
+        postPerform("/auth/signup", signUpReq)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$", containsInAnyOrder(
+                        "아이디를 입력해주세요.",
+                        "휴대폰 번호를 입력해주세요.",
+                        "이메일을 입력해주세요.",
+                        "닉네임을 입력해주세요.",
+                        "이름을 입력해주세요.",
+                        "비밀번호를 입력해주세요.",
+                        "must not be null"
+                )));
+    }
+
+    @Test
+    @DisplayName("이메일 전송 성공")
+    @WithMockUser
+    void server_send_email() throws Exception {
+        EmailDto emailDto = EmailDto.builder()
+                .email("kongminoo@naver.com")
+                .build();
+
+        when(memberService.sendEmail(anyString()))
+                .thenReturn("success@naver.com");
+
+        postPerform("/auth/send-email", emailDto)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value("success@naver.com"));
+    }
+
+    @Test
+    @DisplayName("이메일 인증 성공")
+    @WithMockUser
+    void correct_token_returns_true() throws Exception {
+        TokenVerificationDto tvDto = TokenVerificationDto.builder()
+                .email("test@naver.com")
+                .token("a1s2d3")
+                .build();
+
+        when(memberService.verifyEmail(anyString(), anyString()))
+                .thenReturn(true);
+
+        postPerform("/auth/verify-email", tvDto)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value(true));
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공")
+    @WithMockUser
+    void logout_success() throws Exception {
+        String token = "token";
+
+        when(memberService.logout(anyString()))
+                .thenReturn("memberId");
+
+        mockMvc.perform(post("/api/member/auth/logout")
+                .header(ConstSecurity.AUTHORIZATION, ConstSecurity.BEARER + token)
+                .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value("memberId"));
+    }
+
+    private ResultActions postPerform(String uri, Object requestDto) throws Exception {
+        return mockMvc.perform(post("/api/member" + uri)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+                .andDo(print());
+    }
+
+}


### PR DESCRIPTION
# 🔍이슈
- @EnableJpaAuditing이 패키지 최상단에 있어서 테스트코드 실행 시에 문제가 있어서 위치 이동
- Dto에 기본생성자 추가, 빌더때문에 전체 생성자도 추가
- MethodArgumentNotValidEx가 String으로 되어있어서 하나의 값만 받아왔었음

# 📕 작업 내역
- oauth2 및 securityConfig 패키지 이동
- Dto 기본 생성자 및 전체 생성자 추가
- @EnableJpaAuditing 위치이동
- MethodArgumentNotValidEx에 대한 Globalhandler 리턴타입 String에서 List<String>으로 변경
- 멤버 Auth에 대한 단위 테스트 및 통합 테스트 진행

# 📷 스크린샷
![image](https://github.com/user-attachments/assets/fcfc6081-8d88-4b7f-af9a-2fa0adfd3ae3)


# 📋 PR 유형
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈, 변수명 변경, 임포트 제거 등등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더 추가

# ⛔️ 추가적으로 설명할 내용
-