### PR TITLE
Feature/websocket 2

### DIFF
--- a/src/main/java/com/auction/bid/domain/auction/AuctionService.java
+++ b/src/main/java/com/auction/bid/domain/auction/AuctionService.java
@@ -6,6 +6,5 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 public interface AuctionService {
-//    void saveAuction(Long finalBuyerId, Long productId, Long finalAmount, List<BidDto> bidDtoList);
 
 }

--- a/src/main/java/com/auction/bid/domain/auction/AuctionServiceImpl.java
+++ b/src/main/java/com/auction/bid/domain/auction/AuctionServiceImpl.java
@@ -19,31 +19,4 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class AuctionServiceImpl implements AuctionService {
 
-//    private final ProductRepository productRepository;
-//    private final MemberRepository memberRepository;
-//    private final AuctionRepository auctionRepository;
-//
-//    @Override
-//    public void saveAuction(Long winnerId, Long productId, Long finalAmount, List<BidDto> bidDtoList) {
-//        if (bidDtoList.isEmpty()) return;
-//
-//        Product findProduct = productRepository.findById(productId)
-//                .orElseThrow(() -> new ProductException(ErrorCode.NOT_EXISTS_PRODUCT));
-//
-//        List<Long> memberIds = bidDtoList.stream()
-//                .map(BidDto::getMemberId)
-//                .distinct()
-//                .toList();
-//
-//        List<Member> findMemberList = memberRepository.findAllById(memberIds);
-//
-//        findMemberList.forEach(member -> {
-//            if (Objects.equals(member.getId(), winnerId)) {
-//                auctionRepository.save(Auction.fromBid(member, findProduct, finalAmount, AuctionStatus.BID_SUCCESS));
-//            } else {
-//                auctionRepository.save(Auction.fromBid(member, findProduct, finalAmount, AuctionStatus.BID_FAILURE));
-//            }
-//        });
-//    }
-
 }

--- a/src/main/java/com/auction/bid/domain/bid/BidDto.java
+++ b/src/main/java/com/auction/bid/domain/bid/BidDto.java
@@ -2,6 +2,7 @@ package com.auction.bid.domain.bid;
 
 import com.auction.bid.domain.member.Member;
 import com.auction.bid.domain.product.Product;
+import com.auction.bid.domain.product.ProductBidPhase;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/auction/bid/domain/bid/BidService.java
+++ b/src/main/java/com/auction/bid/domain/bid/BidService.java
@@ -4,6 +4,4 @@ import java.util.List;
 
 public interface BidService {
 
-//    void saveBids(Long productId, List<BidDto> bidDtoList);
-
 }

--- a/src/main/java/com/auction/bid/domain/bid/BidServiceImpl.java
+++ b/src/main/java/com/auction/bid/domain/bid/BidServiceImpl.java
@@ -19,35 +19,4 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class BidServiceImpl implements BidService{
 
-//    private final MemberRepository memberRepository;
-//    private final ProductRepository productRepository;
-//    private final BidRepository bidRepository;
-//
-//    public void saveBids(Long productId, List<BidDto> bidDtoList) {
-//        Product findProduct = productRepository.findById(productId)
-//                .orElseThrow(() -> new ProductException(ErrorCode.NOT_EXISTS_PRODUCT));
-//
-//        if (bidDtoList.isEmpty()) {
-//            bidRepository.save(BidDto.toBidEntity(new BidDto(), null, findProduct));
-//            return;
-//        }
-//
-//        List<Long> memberIds = bidDtoList.stream()
-//                .map(BidDto::getMemberId)
-//                .distinct()
-//                .toList();
-//
-//        List<Member> findMemberList = memberRepository.findAllById(memberIds);
-//        Map<Long, Member> memberMap = findMemberList.stream()
-//                .collect(Collectors.toMap(Member::getId, m -> m));
-//
-//        bidDtoList.stream()
-//                .map(bidDto -> BidDto.toBidEntity(
-//                        bidDto,
-//                        memberMap.get(bidDto.getMemberId()),
-//                        findProduct)
-//                )
-//                .forEach(bidRepository::save);
-//    }
-
 }

--- a/src/main/java/com/auction/bid/domain/member/Member.java
+++ b/src/main/java/com/auction/bid/domain/member/Member.java
@@ -56,7 +56,7 @@ public class Member extends BaseEntity {
     private boolean emailVerified;
 
     @Column(name = "balance")
-    private int balance;
+    private Long balance;
 
     @Column(name = "role")
     private String role;
@@ -64,4 +64,22 @@ public class Member extends BaseEntity {
     @Embedded
     private Address address;
 
+    public Long addBalance(Long chargeMoney) {
+        if (this.balance == null) {
+            setBalance(0L);
+        }
+
+        Long sum = this.balance + chargeMoney;
+        setBalance(sum);
+        return sum;
+    }
+
+    public void subBalance(Long payMoney) {
+        Long sum = this.balance - payMoney;
+        setBalance(sum);
+    }
+
+    private void setBalance(Long balance) {
+        this.balance = balance;
+    }
 }

--- a/src/main/java/com/auction/bid/domain/member/MemberController.java
+++ b/src/main/java/com/auction/bid/domain/member/MemberController.java
@@ -1,5 +1,6 @@
 package com.auction.bid.domain.member;
 
+import com.auction.bid.domain.member.dto.ChargeDto;
 import com.auction.bid.domain.member.dto.EmailDto;
 import com.auction.bid.domain.member.dto.SignUpDto;
 import com.auction.bid.domain.member.dto.TokenVerificationDto;
@@ -39,4 +40,21 @@ public class MemberController {
         return ResponseEntity.ok(memberService.logout(token));
     }
 
+    @PreAuthorize(ConstSecurity.HAS_ROLE_MEMBER)
+    @PostMapping("/charge/money")
+    public ResponseEntity<?> charge(
+            @RequestHeader(ConstSecurity.AUTHORIZATION) String token,
+            @RequestBody ChargeDto.Request dtoRequest) {
+        return ResponseEntity.ok(memberService.chargeMoney(token, dtoRequest));
+    }
+
+    @PreAuthorize(ConstSecurity.HAS_ROLE_MEMBER)
+    @GetMapping("/charge")
+    public ResponseEntity<?> getMoney(
+            @RequestHeader(ConstSecurity.AUTHORIZATION) String token) {
+        return ResponseEntity.ok(memberService.getMoney(token));
+    }
+
+    // 충전 내역 전체 조회 만들지 필요(만들면 entity, repository 만들어야 됨)
+    // 멤버 register할 때 balance를 0L로 등록하기(안하면 NULL이 들어가있음)
 }

--- a/src/main/java/com/auction/bid/domain/member/MemberService.java
+++ b/src/main/java/com/auction/bid/domain/member/MemberService.java
@@ -1,5 +1,6 @@
 package com.auction.bid.domain.member;
 
+import com.auction.bid.domain.member.dto.ChargeDto;
 import com.auction.bid.domain.member.dto.SignUpDto;
 
 import java.util.UUID;
@@ -15,4 +16,14 @@ public interface MemberService {
     String logout(String token);
 
     Member findByMemberUUID(UUID memberUUID);
+
+    ChargeDto.Response chargeMoney(String token, ChargeDto.Request dtoRequest);
+
+    Long getMoney(String token);
+
+    void bidToAuction(Member member, Long money, Long lastMoney);
+
+    void withDraw(Long memberId, Long withDrawMoney);
+
+    void addMoney(Long memberId, Long amount);
 }

--- a/src/main/java/com/auction/bid/domain/member/dto/ChargeDto.java
+++ b/src/main/java/com/auction/bid/domain/member/dto/ChargeDto.java
@@ -1,0 +1,22 @@
+package com.auction.bid.domain.member.dto;
+
+import lombok.*;
+
+public class ChargeDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Request{
+        private Long chargeMoney;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class Response {
+        private Long currMoney;
+    }
+}

--- a/src/main/java/com/auction/bid/domain/photo/Photo.java
+++ b/src/main/java/com/auction/bid/domain/photo/Photo.java
@@ -29,9 +29,8 @@ public class Photo extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name="product_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+//    @OnDelete(action = OnDeleteAction.CASCADE)
     private Product product;
-
 
     public Photo(String dbImagePath, Product product) {
         this.imagePath = dbImagePath;

--- a/src/main/java/com/auction/bid/domain/product/ProductService.java
+++ b/src/main/java/com/auction/bid/domain/product/ProductService.java
@@ -19,6 +19,5 @@ public interface ProductService {
 
     boolean isOnGoing(Long productId);
 
-    ProductDto.Response findById(Long productId);
 
 }

--- a/src/main/java/com/auction/bid/domain/product/dto/ProductDto.java
+++ b/src/main/java/com/auction/bid/domain/product/dto/ProductDto.java
@@ -8,14 +8,13 @@ import com.auction.bid.domain.product.Product;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
-import org.w3c.dom.stylesheets.LinkStyle;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class ProductDto {
-//
+
     @Builder
     @Getter
     @Setter
@@ -63,6 +62,7 @@ public class ProductDto {
         private String description;
         private List<String> imagePath;
         private Long startBid;
+        private ProductBidPhase productBidPhase;
         private LocalDateTime auctionStart;
         private LocalDateTime auctionEnd;
 
@@ -88,6 +88,7 @@ public class ProductDto {
                     .startBid(product.getStartBid())
                     .auctionStart(product.getAuctionStart())
                     .auctionEnd(product.getAuctionEnd())
+                    .productBidPhase(product.getProductBidPhase())
                     .build();
         }
     }

--- a/src/main/java/com/auction/bid/domain/sale/SaleService.java
+++ b/src/main/java/com/auction/bid/domain/sale/SaleService.java
@@ -6,7 +6,5 @@ import java.util.List;
 
 public interface SaleService {
 
-//    void saveSale(Long sellerId, Long buyerId, Long productId, Long finalAmount);
-
 
 }

--- a/src/main/java/com/auction/bid/domain/sale/SaleServiceImpl.java
+++ b/src/main/java/com/auction/bid/domain/sale/SaleServiceImpl.java
@@ -17,24 +17,4 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SaleServiceImpl implements SaleService{
 
-    private final MemberRepository memberRepository;
-    private final ProductRepository productRepository;
-    private final SaleRepository saleRepository;
-
-//    @Override
-//    public void saveSale(Long sellerId, Long buyerId, Long productId, Long finalAmount) {
-//        if (buyerId == null) {
-//            saleRepository.save(Sale.fromAuction(null, SaleStatus.SALE_FAILURE, null, null));
-//            return;
-//        }
-//
-//        Member findBuyer = memberRepository.findById(buyerId)
-//                .orElseThrow(() -> new MemberException(ErrorCode.NOT_EXIST_MEMBER));
-//
-//        Product findProduct = productRepository.findById(productId)
-//                .orElseThrow(() -> new ProductException(ErrorCode.NOT_EXISTS_PRODUCT));
-//
-//        saleRepository.save(Sale.fromAuction(finalAmount, SaleStatus.SALE_SUCCESS, findBuyer, findProduct));
-//    }
-
 }

--- a/src/main/java/com/auction/bid/global/exception/ErrorCode.java
+++ b/src/main/java/com/auction/bid/global/exception/ErrorCode.java
@@ -42,8 +42,13 @@ public enum ErrorCode {
     NOT_EXIST_AUCTION("해당 경매는 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
     BID_AMOUNT_TOO_LOW("현재 경매가보다 입찰 금액이 높아야합니다.", HttpStatus.BAD_REQUEST),
 
+    // MoneyException
+    NOT_ENOUGH_MONEY("돈이 충분하지 않습니다.", HttpStatus.BAD_REQUEST),
+
     // SocketException
     FAILED_TO_CONNECT_WS("웹소켓 연결에 실패하였습니다.", HttpStatus.BAD_REQUEST);
+
+
 
 
     private final String description;

--- a/src/main/java/com/auction/bid/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/auction/bid/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.auction.bid.global.exception;
 
 import com.auction.bid.global.exception.exceptions.*;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -10,36 +11,61 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.List;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(MemberException.class)
-    public ResponseEntity<String> handleMemberException(MemberException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-    }
-
-    @ExceptionHandler(MailException.class)
-    public ResponseEntity<String> handleMailException(MailException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-    }
-
     @ExceptionHandler(AuthException.class)
     public ResponseEntity<String> handleAuthException(AuthException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-    }
-
-    @ExceptionHandler(CategoryException.class)
-    public ResponseEntity<String> handleCategoryException(CategoryException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
-    }
-
-    @ExceptionHandler(SocketException.class)
-    public ResponseEntity<String> handleSocketException(SocketException ex) {
+        log.error("AuthException 발생: {}", ex.getMessage(), ex);
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(BidException.class)
     public ResponseEntity<String> handleBidException(BidException ex) {
+        log.error("BidException 발생: {}", ex.getMessage(), ex);
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(CategoryException.class)
+    public ResponseEntity<String> handleCategoryException(CategoryException ex) {
+        log.error("CategoryException 발생: {}", ex.getMessage(), ex);
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MailException.class)
+    public ResponseEntity<String> handleMailException(MailException ex) {
+        log.error("MailException 발생: {}", ex.getMessage(), ex);
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<String> handleMemberException(MemberException ex) {
+        log.error("MemberException 발생: {}", ex.getMessage(), ex);
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MoneyException.class)
+    public ResponseEntity<String> handleMoneyException(MoneyException ex) {
+        log.error("MoneyException 발생: {}", ex.getMessage(), ex);
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(PhotoException.class)
+    public ResponseEntity<String> handlePhotoException(PhotoException ex) {
+        log.error("PhotoException 발생: {}", ex.getMessage(), ex);
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ProductException.class)
+    public ResponseEntity<String> handleProductException(ProductException ex) {
+        log.error("ProductException 발생: {}", ex.getMessage(), ex);
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(SocketException.class)
+    public ResponseEntity<String> handleSocketException(SocketException ex) {
+        log.error("SocketException 발생: {}", ex.getMessage(), ex);
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
@@ -48,11 +74,13 @@ public class GlobalExceptionHandler {
         List<String> errors = ex.getBindingResult().getFieldErrors().stream()
                 .map(FieldError::getDefaultMessage)
                 .toList();
+        log.error("MethodArgumentNotValidException 발생: {}", errors);
         return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<String> handleException(Exception ex) {
+        log.error("RuntimeException 발생: {}", ex.getMessage(), ex);
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/com/auction/bid/global/exception/exceptions/MoneyException.java
+++ b/src/main/java/com/auction/bid/global/exception/exceptions/MoneyException.java
@@ -1,0 +1,16 @@
+package com.auction.bid.global.exception.exceptions;
+
+import com.auction.bid.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class MoneyException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+    public MoneyException(ErrorCode errorCode) {
+        super(errorCode.getDescription());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/auction/bid/global/scheduler/AuctionScheduler.java
+++ b/src/main/java/com/auction/bid/global/scheduler/AuctionScheduler.java
@@ -1,13 +1,9 @@
 package com.auction.bid.global.scheduler;
 
-import com.auction.bid.domain.auction.AuctionService;
 import com.auction.bid.domain.bid.BidDto;
-import com.auction.bid.domain.bid.BidService;
+import com.auction.bid.domain.member.MemberService;
 import com.auction.bid.domain.product.ProductBidPhase;
 import com.auction.bid.domain.product.Product;
-import com.auction.bid.domain.product.ProductService;
-import com.auction.bid.domain.product.ProductServiceImpl;
-import com.auction.bid.domain.sale.SaleService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.HashOperations;
@@ -16,8 +12,10 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import static com.auction.bid.global.scheduler.ConstAuction.AUCTION;
 
@@ -28,6 +26,7 @@ public class AuctionScheduler {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final SchedulerService schedulerService;
+    private final MemberService memberService;
 
     @TransactionalEventListener
     @Async
@@ -37,10 +36,15 @@ public class AuctionScheduler {
 
         HashOperations<String, Long, List<BidDto>> openedAuctionRedis = redisTemplate.opsForHash();
         openedAuctionRedis.put(AUCTION, product.getId(), new ArrayList<>());
+        LocalDateTime auctionStart = product.getAuctionStart();
+        LocalDateTime auctionEnd = product.getAuctionEnd();
+        long ttl = Duration.between(auctionStart, auctionEnd).getSeconds() + 3600;
+        redisTemplate.expire(AUCTION, ttl, TimeUnit.SECONDS);
     }
 
     @Async
     public void closeAuction(Product product) {
+        // 트랜잭션 관리 제대로 해야됨 추후에 생각해볼것
         log.info("경매 종료={}", product.getAuctionEnd());
         schedulerService.changeAuctionPhase(product, ProductBidPhase.ENDED);
 
@@ -48,9 +52,31 @@ public class AuctionScheduler {
         List<BidDto> bidDtoList = BidDto
                 .convertToBidDtoList(openedAuctionRedis.get(AUCTION, product.getId()));
 
-        BidDto bidDto = bidDtoList.isEmpty() ? new BidDto() : bidDtoList.get(bidDtoList.size() - 1);
-        Long finalAmount = bidDto.getBidAmount();
-        Long finalBuyerId = bidDto.getMemberId();
+        BidDto successBidDto = bidDtoList.isEmpty() ? new BidDto() : bidDtoList.get(bidDtoList.size() - 1);
+        Long successMemberId = successBidDto.getMemberId();
+        Long finalAmount = successBidDto.getBidAmount();
+        Long finalBuyerId = successBidDto.getMemberId();
+        
+        Map<Long, Long> withDrawMap = new HashMap<>();
+        for (int i = bidDtoList.size() - 2; i >= 0; i--) {
+            BidDto bidDto = bidDtoList.get(i);
+            if (Objects.equals(bidDto.getMemberId(), successMemberId)) continue;
+            Long memberId = bidDto.getMemberId();
+            Long bidAmount = bidDto.getBidAmount();
+            
+            if (withDrawMap.containsKey(memberId)) continue;
+            withDrawMap.put(memberId, bidAmount);
+        }
+
+        for (Map.Entry<Long, Long> entry : withDrawMap.entrySet()) {
+            Long memberId = entry.getKey();
+            Long bidAmount = entry.getValue();
+            memberService.withDraw(memberId, bidAmount);
+        }
+
+        if (successMemberId != null) {
+            memberService.addMoney(product.getMember().getId(), finalAmount);
+        }
 
         schedulerService.saveBids(product.getId(), bidDtoList);
         log.info("입찰 저장 완료");
@@ -61,6 +87,10 @@ public class AuctionScheduler {
         schedulerService.saveSale(finalBuyerId, product.getId(), finalAmount);
         log.info("판매 저장 완료");
 
+        // 서버가 종료되었을 때, 대기 중인 레디스 다 삭제됨. repository하나 만들어서 서버 시작에 재등록하고 openAuction때 repository에 관리해야 됨
+        // 상품이 Integer.MaxValue를 넘어도 잘 작동할까?(url로 지정해서..)
+        // 레디스를 사용한 이유는 서버의 부하를 막기 위해서였다.
+        // 하지만 웹소켓만으로 대용량을 처리할 수 있을까?(카프카란 걸 같이 사용해야 할 거 같다..)
         openedAuctionRedis.delete(AUCTION, product.getId());
     }
 

--- a/src/main/java/com/auction/bid/global/scheduler/SchedulerService.java
+++ b/src/main/java/com/auction/bid/global/scheduler/SchedulerService.java
@@ -15,7 +15,9 @@ import com.auction.bid.domain.sale.SaleRepository;
 import com.auction.bid.domain.sale.SaleStatus;
 import com.auction.bid.global.exception.ErrorCode;
 import com.auction.bid.global.exception.exceptions.MemberException;
+import com.auction.bid.global.exception.exceptions.MoneyException;
 import com.auction.bid.global.exception.exceptions.ProductException;
+import com.auction.bid.global.websocket.WebSocketBidHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,14 +39,19 @@ public class SchedulerService {
     private final MemberRepository memberRepository;
     private final AuctionRepository auctionRepository;
     private final SaleRepository saleRepository;
-
+    private final WebSocketBidHandler webSocketBidHandler;
 
     public void changeAuctionPhase(Product product, ProductBidPhase productBidPhase) {
         product.changeAuctionPhase(productBidPhase);
         productRepository.save(product);
+        webSocketBidHandler.phaseChange(product.getId(), productBidPhase);
     }
 
     public void saveBids(Long productId, List<BidDto> bidDtoList) {
+        if (bidDtoList.isEmpty()) {
+            return;
+        }
+
         Product findProduct = productRepository.findById(productId)
                 .orElseThrow(() -> new ProductException(ErrorCode.NOT_EXISTS_PRODUCT));
 

--- a/src/main/java/com/auction/bid/global/websocket/WebSocketBidHandler.java
+++ b/src/main/java/com/auction/bid/global/websocket/WebSocketBidHandler.java
@@ -114,6 +114,14 @@ public class WebSocketBidHandler extends TextWebSocketHandler {
             return;
         }
 
+        if (!bidList.isEmpty()) {
+            List<BidDto> bidDtos = BidDto.convertToBidDtoList(bidList);
+            BidDto bidDto = bidDtos.get(bidDtos.size() - 1);
+            if (Objects.equals(bidDto.getMemberId(), member.getId())) {
+                sendMessage(session, "현재 최고 입찰자는 본인입니다.");
+                return;
+            }
+        }
         // 세션을 기준으로 돈 작성 시에 새로운 세션에의 같은 멤버는 제대로 된 입찰이 불가능 해짐
         // 추후에 레디스를 이용해 별도로 입찰 금액을 꺼내와야 됨
 

--- a/src/main/java/com/auction/bid/global/websocket/WebSocketBidHandler.java
+++ b/src/main/java/com/auction/bid/global/websocket/WebSocketBidHandler.java
@@ -2,11 +2,13 @@ package com.auction.bid.global.websocket;
 
 import com.auction.bid.domain.bid.BidDto;
 import com.auction.bid.domain.member.Member;
+import com.auction.bid.domain.member.MemberService;
 import com.auction.bid.domain.product.Product;
 import com.auction.bid.domain.product.ProductBidPhase;
-import com.auction.bid.domain.product.ProductService;
+import com.auction.bid.domain.product.ProductRepository;
 import com.auction.bid.global.exception.ErrorCode;
-import com.auction.bid.global.exception.exceptions.BidException;
+import com.auction.bid.global.exception.exceptions.MoneyException;
+import com.auction.bid.global.exception.exceptions.ProductException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +23,7 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Stream;
 
 import static com.auction.bid.global.scheduler.ConstAuction.AUCTION;
 import static com.auction.bid.global.websocket.ConstWebsocket.MEMBER;
@@ -32,8 +35,9 @@ import static com.auction.bid.global.websocket.ConstWebsocket.PRODUCT_ID;
 public class WebSocketBidHandler extends TextWebSocketHandler {
 
     private final ObjectMapper objectMapper;
-    private final ProductService productService;
+    private final ProductRepository productRepository;
     private final RedisTemplate<String, Object> redisTemplate;
+    private final MemberService memberService;
 
     private final Set<WebSocketSession> sessions = new HashSet<>();
     private final Map<Long, Set<WebSocketSession>> roomSessionMap = new HashMap<>();
@@ -44,56 +48,60 @@ public class WebSocketBidHandler extends TextWebSocketHandler {
         Member findMember = (Member) attributes.get(MEMBER);
         Long productId = (Long) attributes.get(PRODUCT_ID);
 
-        if (findMember == null || productId == null) {
-            closeOneSession(session);
-        }
-
         sendViewerCountToBidRoom(getSocketSetWhenEntered(productId, session));
         sessions.add(session);
 
-        List<BidDto> bidDtoList;
-        try {
-            bidDtoList = BidDto.convertToBidDtoList(
-                    bidListFromRedis(
-                            productId,
-                            roomSessionMap.get(productId)
-                    ));
-        } catch (BidException e) {
-            log.info("경매 종료={}", e.getMessage());
-            return;
-        }
+        List<BidDto> bidDtoList = BidDto.convertToBidDtoList(
+                bidListFromRedis(productId)
+        );
 
         BidDto bidDto = bidDtoList.isEmpty() ? BidDto.emptyDtoList(productId) :
                 bidDtoList.get(bidDtoList.size() - 1);
 
         sendMessageToEntrant(bidDto, session);
 
-        log.info("[{}] 연결됨", findMember.getId());
+        if (findMember == null) {
+            log.info("[sessionId={}] 연결됨", session.getId());
+        } else {
+            log.info("[memberId={}] 연결됨", findMember.getId());
+        }
     }
 
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
         Map<String, Object> attributes = session.getAttributes();
         Member member = (Member) attributes.get(MEMBER);
+
+        if (member == null) {
+            sendMessage(session, "로그인해야 입찰이 가능합니다.");
+            return;
+        }
+
         Long productId = (Long) attributes.get(PRODUCT_ID);
+        Product findProduct = productRepository.findById(productId)
+                .orElseThrow(() -> new ProductException(ErrorCode.NOT_EXISTS_PRODUCT));
 
-        Product findProduct = productService.findById(productId);
+        if (findProduct.getProductBidPhase() == ProductBidPhase.ENDED) {
+            sendMessage(session, "경매가 종료되었습니다.");
+            return;
+        }
+
+        if (findProduct.getProductBidPhase() == ProductBidPhase.BEFORE) {
+            sendMessage(session, "경매가 시작되야 입찰을 할 수 있습니다..");
+            return;
+        }
+
         Set<WebSocketSession> bidRoomSessions = getWebSocketSessions(productId);
-
-        if (findProduct.getProductBidPhase() != ProductBidPhase.ONGOING) {
-            closeAllSessions(bidRoomSessions);
+        if (Objects.equals(findProduct.getMember().getId(), member.getId())) {
+            sendMessage(session, "상품 판매자는 입찰할 수 없습니다.");
+            return;
         }
 
         String payload = message.getPayload();
         MessageDto.Request dtoRequest = objectMapper.readValue(payload, MessageDto.Request.class);
 
         List<BidDto> bidList;
-        try {
-            bidList = bidListFromRedis(productId, roomSessionMap.get(productId));
-        } catch (BidException e) {
-            log.info("경매 종료={}", e.getMessage());
-            return;
-        }
+        bidList = bidListFromRedis(productId);
 
         Long currMaxBidAmount = getMaxBidAmount(bidList, findProduct.getStartBid());
         if (currMaxBidAmount >= dtoRequest.getBidAmount()) {
@@ -101,12 +109,30 @@ public class WebSocketBidHandler extends TextWebSocketHandler {
             return;
         }
 
-        // 현재 잔액에서의 예외와 잔액 소모시켜야됨
-        // 잔액 돌려주기는 redis에서 해야할 듯??
-        // 가입안한 회원이와도 되는지 확인
+        if (dtoRequest.getMaxBidLimit() < dtoRequest.getBidAmount()) {
+            sendMessage(session, "입찰한계금액보다 입찰금액은 작아야합니다.");
+            return;
+        }
+
+        // 세션을 기준으로 돈 작성 시에 새로운 세션에의 같은 멤버는 제대로 된 입찰이 불가능 해짐
+        // 추후에 레디스를 이용해 별도로 입찰 금액을 꺼내와야 됨
+
+        try {
+            Long lastMoney = (Long) attributes.get("lastMoney");
+            if (lastMoney == null) {
+                lastMoney = 0L;
+            }
+
+            memberService.bidToAuction(member, dtoRequest.getBidAmount(), lastMoney);
+            attributes.put("lastMoney", dtoRequest.getBidAmount());
+        } catch (MoneyException | NullPointerException e) {
+            log.info("MoneyEx={}", e.getMessage());
+            sendMessage(session, "잔액이 부족합니다.");
+            return;
+        }
 
         MessageDto.Response response = MessageDto.Response
-                        .fromRequest(member, productId, dtoRequest.getBidAmount());
+                .fromRequest(member, productId, dtoRequest.getBidAmount());
 
         putInRedis(productId, member, dtoRequest, bidList);
         sendMessageToBidRoom(response, bidRoomSessions);
@@ -115,13 +141,11 @@ public class WebSocketBidHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         Map<String, Object> attributes = session.getAttributes();
-        Member member;
-        Long productId;
-        try {
-            member = (Member) attributes.get(MEMBER);
-            productId = (Long) attributes.get(PRODUCT_ID);
-        } catch (NullPointerException e) {
-            log.info("NullPointerEx={}", e.getMessage());
+        Member member = (Member) attributes.get(MEMBER);
+        Long productId = (Long) attributes.get(PRODUCT_ID);
+
+        if (member == null) {
+            log.info("{} 연결 끊김", session.getId());
             return;
         }
 
@@ -129,6 +153,15 @@ public class WebSocketBidHandler extends TextWebSocketHandler {
         sessions.remove(session);
         sendViewerCountToBidRoom(getWebSocketSessions(productId));
         log.info("{} 연결 끊김", member.getId());
+    }
+
+    public void phaseChange(Long productId, ProductBidPhase phase) {
+        Set<WebSocketSession> webSocketSessions = getWebSocketSessions(productId);
+        webSocketSessions.parallelStream().forEach(session -> sendMessage(session, phase));
+        if (phase == ProductBidPhase.ENDED){
+            closeAllSessions(webSocketSessions);
+        }
+
     }
 
     private void sendMessageToBidRoom(MessageDto.Response res, Set<WebSocketSession> bidRoomSession) {
@@ -143,6 +176,7 @@ public class WebSocketBidHandler extends TextWebSocketHandler {
                 .filter(WebSocketSession::isOpen)
                 .forEach(sess -> sendMessage(sess, viewerCnt));
     }
+
 
     private <T> void sendMessage(WebSocketSession session, T message) {
         try {
@@ -161,7 +195,7 @@ public class WebSocketBidHandler extends TextWebSocketHandler {
     }
 
     private Set<WebSocketSession> getWebSocketSessions(Long productId) {
-        if(!roomSessionMap.containsKey(productId)){
+        if (!roomSessionMap.containsKey(productId)) {
             roomSessionMap.put(productId, new HashSet<>());
         }
 
@@ -174,7 +208,7 @@ public class WebSocketBidHandler extends TextWebSocketHandler {
     }
 
     private Set<WebSocketSession> getSocketSetWhenEntered(Long productId, WebSocketSession webSocketSession) {
-        if(!roomSessionMap.containsKey(productId)){
+        if (!roomSessionMap.containsKey(productId)) {
             roomSessionMap.put(productId, new HashSet<>());
         }
 
@@ -191,30 +225,28 @@ public class WebSocketBidHandler extends TextWebSocketHandler {
         bidRoomSession.removeIf(sess -> !sessions.contains(sess));
     }
 
-    private List<BidDto> bidListFromRedis(Long productId, Set<WebSocketSession> bidRoomSession) {
+    private List<BidDto> bidListFromRedis(Long productId) {
         HashOperations<String, Long, List<BidDto>> auctionRedis = redisTemplate.opsForHash();
-
-        if (!auctionRedis.hasKey(AUCTION, productId)) {
-            closeAllSessions(bidRoomSession);
-            throw new BidException(ErrorCode.NOT_EXIST_AUCTION);
-        }
+        if (!auctionRedis.hasKey(AUCTION, productId)) return new ArrayList<>();
 
         return auctionRedis.get(AUCTION, productId);
     }
 
     private void closeAllSessions(Set<WebSocketSession> bidRoomSession) {
-        bidRoomSession.parallelStream().forEach(session -> {
-            Map<String, Object> attributes = session.getAttributes();
-            Long productId = (Long) attributes.get(PRODUCT_ID);
-            roomSessionMap.get(productId).remove(session);
-            try {
-                sendMessage(session, "경매를 진행할 수 없습니다.");
+        Iterator<WebSocketSession> iterator = bidRoomSession.iterator();
+
+        while (iterator.hasNext()) {
+            WebSocketSession session = iterator.next();
+            if (session.isOpen()) {
+                iterator.remove();
                 sessions.remove(session);
-                session.close();
-            } catch (IOException e) {
-                log.error("웹소켓 세션 종료 실패: sessionId={}", session.getId(), e);
+                try {
+                    session.close();
+                } catch (IOException e) {
+                    log.error("웹소켓 세션 종료 실패: sessionId={}", session.getId(), e);
+                }
             }
-        });
+        }
     }
 
     private void closeOneSession(WebSocketSession session) {
@@ -244,7 +276,7 @@ public class WebSocketBidHandler extends TextWebSocketHandler {
     }
 
     private Long getMaxBidAmount(List<BidDto> bidList, long startBid) {
-        if (bidList.isEmpty()){
+        if (bidList.isEmpty()) {
             return startBid - 1;
         }
 


### PR DESCRIPTION
# 🔍이슈
- 이전에 PR했던 웹소켓은 입찰 금액을 제외하고 구현했었습니다.
- 이번 구현에 입찰 금액까지 구현에 완료했습니다.
- 로그인을 하지않아도 입찰은 안되지만 조회는 되게끔 구현했습니다.


# 📕 작업 내역
- 돈 충전, 조회 구현
- 예외 추가 및 리팩터링
- 웹소켓 마무리

# 📷 스크린샷

* * *
<h1>경매 전</h1>
<img width="1645" alt="스크린샷 2024-12-23 오후 10 36 32" src="https://github.com/user-attachments/assets/363c283a-ae5e-40aa-8ed2-441441f523c4" />
(레디스에 아무값도 안 들어와있는 사진)

* * *

![스크린샷 2024-12-23 오후 10 38 44](https://github.com/user-attachments/assets/42215c50-6bd3-4396-9414-23366b3615cb)
(멤버 5명에 1번 멤버가 상품등록하고 각각 1~5만원씩 충전한 사진)

* * *
![스크린샷 2024-12-23 오후 10 39 30](https://github.com/user-attachments/assets/c63853f7-2905-48cf-9455-ddaab45288fa)
(가장 우측에 있는 열을 보면 BEFORE, 경매가 시작 전이라는 것을 알 수 있다)

* * *

<h1>경매 중</h1>
<img width="1576" alt="스크린샷 2024-12-23 오후 10 41 51" src="https://github.com/user-attachments/assets/57709c78-3d5a-4d60-a07b-5c84821c4907" />

(입찰했던 정보가 레디스가 담아있는 사진)

* * *

![스크린샷 2024-12-23 오후 10 42 03](https://github.com/user-attachments/assets/f2a45705-05c1-4e33-b4d3-48e48a5d7aa9)
(가장 우측에 있는 열을 보면 ONGOING, 경매가 진행 중이라는 것을 알 수 있다)

![스크린샷 2024-12-23 오후 10 42 09](https://github.com/user-attachments/assets/96a0c9ee-b795-45b6-a1d2-8c24c5c35710)
(입찰을 넣은 뒤 현재 멤버들에게 남아있는 잔액(balance))

* * *

<h1>경매 끝</h1>

![스크린샷 2024-12-23 오후 10 43 41](https://github.com/user-attachments/assets/60e4e458-a5ed-40b6-9eff-1e6cf7cfafbe)
(가장 우측에 있는 열을 보면 END, 경매가 종료 되었다는 것을 알 수 있다)

* * *

![스크린샷 2024-12-23 오후 10 43 52](https://github.com/user-attachments/assets/59342961-97c7-4c3c-847a-c90502f2bcd4)
(판매자는 낙찰된 금액을 더했고 낙찰자는 경매에서 사용된 금액을 차감시켰다. 나머지 멤버들은 경매에 낙찰되지 못했으니 남은 금액들을 반환해주었다.)

* * *

![스크린샷 2024-12-23 오후 11 05 45](https://github.com/user-attachments/assets/b68fd89b-80a9-4eca-b901-9613f593ca1b)

* * *

![스크린샷 2024-12-23 오후 11 05 53](https://github.com/user-attachments/assets/80fe5961-6aa3-4b96-9ef6-a97639985a98)

* * *

![스크린샷 2024-12-23 오후 11 05 58](https://github.com/user-attachments/assets/742001ab-0bef-4918-b1ff-e52ad3a5835c)
(결과물은 db에 잘 저장되었다.)

* * *

<img width="1595" alt="스크린샷 2024-12-23 오후 10 44 01" src="https://github.com/user-attachments/assets/f8fc068c-5856-430f-87be-ae99d223aaf0" />
(이후 레디스에 값이 비어있고 db에 다 저장되었다.)

* * *

<h1>경매 진행했던 사진</h1>

![스크린샷 2024-12-23 오후 10 45 17](https://github.com/user-attachments/assets/76664bd7-7f19-4a69-9649-3e6dec84d43a)
(멤버 1)

* * *

![스크린샷 2024-12-23 오후 10 45 10](https://github.com/user-attachments/assets/f3d85224-5bcf-40c8-afc7-c832937a18ed)
(멤버 2)

* * *

![스크린샷 2024-12-23 오후 10 45 02](https://github.com/user-attachments/assets/b6d7ccc9-d854-4975-b8bb-ad08c9860439)
(멤버 3)

* * *

![스크린샷 2024-12-23 오후 10 44 52](https://github.com/user-attachments/assets/f2c5f55e-390d-423c-8885-0eebbff74f22)
(멤버 4)

* * *

![스크린샷 2024-12-23 오후 10 44 42](https://github.com/user-attachments/assets/6d6a35e0-9b11-4c71-95b3-aa65e89c71fc)
(멤버 5)

* * *

![image](https://github.com/user-attachments/assets/07273cd7-caa9-4f12-9506-c25b3b266b34)
(로그인하지 않은 유저, 입찰을 진행하진 않았지만 입찰을 하게되면 로그인 해야 이용가능하다고 문구가 뜸)

<img width="825" alt="image" src="https://github.com/user-attachments/assets/cd3af9c8-2312-4ee4-9fa2-79aeb771b685" />
(본인이 최고입찰자라면 입찰 리턴)

# 📋 PR 유형
- [x] 기능 추가
- [ ] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈, 변수명 변경, 임포트 제거 등등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [x] API Test
- [ ] 빌드 부분
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더 추가

# ⛔️ 추가적으로 설명할 내용
- 현재 계획했던 경매 시나리오
   1. 판매자가 상품을 경매 시작일과 종료일에 맞춰 등록한다.
   2. 서버에서는 동적으로 시작일 때 상품 상태가 Before 에서 OnGoing으로 바뀐 뒤, 레디스에 상품의 정보가 올라간다.
   3. 이후 유저들은 입찰을 진행한다.
   4. 로그인을 하지 않았다면 조회는 가능하지만 입찰은 진행할 수 없다, 유저들은 입찰한도금액 및 본인이 충전한 금액에 맞춰서 입찰을 진행할 수 있다. 또, 최고입찰자가 본인이라면 리턴된다.
   5. 경매의 종료일이 오면 OnGoing에서 Ended로 바뀐 후, 레디스에 있던 입찰 순서 및 금액들은 Db에 잘 저장된다.(위 사진 참고) 이후 레디스는 삭제된다.

- 현재까지 구현했던 것의 문제점
    1. 입찰에 있어서 같은 유저가 두 번의 입찰을 진행할 때, 세션 기반으로 가장 최근의 금액을 불러와서 웹소켓이 종료되었을 경우 최신 금액에서 차감이 불가능 함 -> 추후 레디스로 구현을 바꿀 것을 고려.
    2. 레디스는 결국 대용량 트래픽에서 서버의 부담을 줄여주기위해 사용했지만 결국 큰 트래픽이 발생했을 경우에는 웹소켓만으로 안되고 카프카란 것을 같이 써야한는 거 같음.
    3. 서버가 종료되었을 시, 기존에 저장되어있던 쓰레드들이 날라가기 때문에 별도로 저장하고 서버 시작 시에 다시 백그라운드에 쓰레드 저장해야됨.
    4. 돈과 직결된 거래여서 예외가 터지면 큰일남. 트랜잭션도 다시 살펴봐야됨